### PR TITLE
Add Slack + Github actions

### DIFF
--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -1,0 +1,37 @@
+name: Notify Applications team on "Ready for review" PRs
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  notify-slack:
+    if: github.event.label.name == 'Ready for review'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send notification to Slack
+        run: |
+          SLACK_WEBHOOK_URL="${{ secrets.SLACK_WEBHOOK_URL }}"
+          PR_NR="${{ github.event.pull_request.number }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+          PR_ADDITIONS="${{ github.event.pull_request.additions }}"
+          PR_DELETIONS="${{ github.event.pull_request.deletions }}"
+          REPO_NAME="${{ github.event.repository.name }}"
+
+          curl -X POST -H 'Content-type: application/json' \
+          --data "{
+            \"text\": \"*Pull Request Ready for Review!*\", 
+            \"blocks\": [
+              {
+                \"type\": \"section\",
+                \"text\": {
+                  \"type\": \"mrkdwn\",
+                  \"text\": \"@applications-team: :rocket: PR by ${PR_AUTHOR} needs a review: \`+${PR_ADDITIONS} -${PR_DELETIONS}\` <${PR_URL}|${REPO_NAME}#${PR_NR}: ${PR_TITLE}>\"
+                }
+              }
+            ]
+          }" \
+          $SLACK_WEBHOOK_URL

--- a/.github/workflows/reminder.yml
+++ b/.github/workflows/reminder.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Send reminders for PRs with "Ready for review"
         run: |
@@ -31,12 +31,16 @@ jobs:
             _jq() {
               echo ${row} | base64 --decode | jq -r ${1}
             }
-            PR_NR=$(_jq '.number')
+            PR_NUMBER=$(_jq '.number')
             PR_TITLE=$(_jq '.title')
             PR_URL=$(_jq '.html_url')
             PR_AUTHOR=$(_jq '.user.login')
-            PR_ADDITIONS=$(_jq '.additions')
-            PR_DELETIONS=$(_jq '.deletions')
+
+            PR_DETAILS=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              "https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUMBER}")
+            PR_ADDITIONS=$(echo $PR_DETAILS | jq '.additions')
+            PR_DELETIONS=$(echo $PR_DETAILS | jq '.deletions')
+            REPO_NAME=$(echo $PR_DETAILS | jq '.base.repo.full_name')
 
             # Send Slack notification
             curl -X POST -H 'Content-type: application/json' \
@@ -47,14 +51,14 @@ jobs:
                   \"type\": \"section\",
                   \"text\": {
                     \"type\": \"mrkdwn\",
-                    \"text\": \":warning: *Reminder:* Pull Request <${PR_URL}|#${PR_NR}> is still in review, please take a look!\"
+                    \"text\": \":warning: *Reminder:* Pull Request <${PR_URL}|#${PR_NUMBER}> still needs a reviewer, please take a look!\"
                   }
                 },
                 {
                   \"type\": \"section\",
                   \"text\": {
                     \"type\": \"mrkdwn\",
-                    \"text\": \":rocket: PR by ${PR_AUTHOR} needs a review: \`+${PR_ADDITIONS} -${PR_DELETIONS}\` <${PR_URL}|${REPO_NAME}#${PR_NR}: ${PR_TITLE}>\"
+                    \"text\": \":rocket: PR by ${PR_AUTHOR} needs a review: \`+${PR_ADDITIONS} -${PR_DELETIONS}\` <${PR_URL}|${REPO_NAME}#${PR_NUMBER}: ${PR_TITLE}>\"
                   }
                 }
               ]

--- a/.github/workflows/reminder.yml
+++ b/.github/workflows/reminder.yml
@@ -1,0 +1,63 @@
+name: Periodic PR Reminders
+
+on:
+  schedule:
+    - cron: '0 */3 * * *' # Runs every 3 hours
+
+jobs:
+  reminder:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Send reminders for PRs with "Ready for review"
+        run: |
+          SLACK_WEBHOOK_URL="${{ secrets.SLACK_WEBHOOK_URL }}"
+          
+          # Fetch PRs with "Ready for review" label
+          PRS=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/issues?labels=Ready%20for%20review&state=open&per_page=100")
+          PR_COUNT=$(echo $PRS | jq '. | length')
+          
+          if [ "$PR_COUNT" -eq 0 ]; then
+            echo "No PRs with 'Ready for review' label found."
+            exit 0
+          fi
+
+          # Iterate over each PR and send a reminder
+          for row in $(echo "${PRS}" | jq -r '.[] | @base64'); do
+            _jq() {
+              echo ${row} | base64 --decode | jq -r ${1}
+            }
+            PR_NR=$(_jq '.number')
+            PR_TITLE=$(_jq '.title')
+            PR_URL=$(_jq '.html_url')
+            PR_AUTHOR=$(_jq '.user.login')
+            PR_ADDITIONS=$(_jq '.additions')
+            PR_DELETIONS=$(_jq '.deletions')
+
+            # Send Slack notification
+            curl -X POST -H 'Content-type: application/json' \
+            --data "{
+              \"text\": \"*Reminder:* Pull Request '${PR_TITLE}' is still in review, please take a look!\",
+              \"blocks\": [
+                {
+                  \"type\": \"section\",
+                  \"text\": {
+                    \"type\": \"mrkdwn\",
+                    \"text\": \":warning: *Reminder:* Pull Request <${PR_URL}|#${PR_NR}> is still in review, please take a look!\"
+                  }
+                },
+                {
+                  \"type\": \"section\",
+                  \"text\": {
+                    \"type\": \"mrkdwn\",
+                    \"text\": \":rocket: PR by ${PR_AUTHOR} needs a review: \`+${PR_ADDITIONS} -${PR_DELETIONS}\` <${PR_URL}|${REPO_NAME}#${PR_NR}: ${PR_TITLE}>\"
+                  }
+                }
+              ]
+            }" \
+            $SLACK_WEBHOOK_URL
+          done

--- a/.github/workflows/reminder.yml
+++ b/.github/workflows/reminder.yml
@@ -45,7 +45,7 @@ jobs:
             # Send Slack notification
             curl -X POST -H 'Content-type: application/json' \
             --data "{
-              \"text\": \"*Reminder:* Pull Request '${PR_TITLE}' is still in review, please take a look!\",
+              \"text\": \"*Reminder:* Pull Request '${PR_TITLE}' needs a reviewer!\",
               \"blocks\": [
                 {
                   \"type\": \"section\",

--- a/.github/workflows/remove-label-when-approved.yml
+++ b/.github/workflows/remove-label-when-approved.yml
@@ -2,7 +2,7 @@ name: Remove "Ready for review" label on PR approval
 
 on:
   pull_request_review:
-    types: [ submitted ]
+    types: [submitted]
 
 jobs:
   remove-label-on-approval:
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Remove "Ready for review" label from PR
         uses: actions/github-script@v6

--- a/.github/workflows/remove-label-when-approved.yml
+++ b/.github/workflows/remove-label-when-approved.yml
@@ -1,0 +1,39 @@
+name: Remove "Ready for review" label on PR approval
+
+on:
+  pull_request_review:
+    types: [ submitted ]
+
+jobs:
+  remove-label-on-approval:
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Remove "Ready for review" label from PR
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+
+            const labelToRemove = 'Ready for review';
+            const labels = pullRequest.labels.map(label => label.name);
+
+            if (labels.includes(labelToRemove)) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: labelToRemove
+              });
+              console.log(`Removed label: ${labelToRemove}`);
+            } else {
+              console.log(`Label ${labelToRemove} not found on PR.`);
+            }


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

We (maintainers) should be aware of any PRs that are waiting for reviews

## Changes

- Add workflow for sending slack message when 'Ready for review' label has been added
- Add workflow for reminding about pending PR reviews every 3 hrs (AFAIK will not be active until it is merged to main)
- Add workflow for removing the label once PR has been approved

