### PR TITLE
[APP-3269] Add minimum requirements.txt, fix codeowners/env name

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,15 @@
+# This file defines which domain owns what parts of this repository.
+#
+# The syntax is the same as defined in
+# https://help.github.com/articles/about-codeowners/
+#
+# Important Rules:
+# 1. The last matching pattern in this file takes precedence
+#
+# 2. Only domains (github team) own code, not individuals
+#    see list at https://github.com/orgs/datarobot-oss/teams
+#
+# Default owners for everything in the repo.
+# Unless a later match takes precedence, these groups will be requested for
+# review when someone opens a pull request.
+*   @datarobot-oss/applications-oss

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,0 +1,2 @@
+streamlit>=1.38.0
+datarobot>=3.5.2

--- a/template_info.json
+++ b/template_info.json
@@ -15,5 +15,5 @@
    },
    "templateType":"customApplicationTemplate",
    "templateSubType":"customApplicationTemplate",
-   "executionEnvironmentName":"[DataRobot] Python 3.12 Streamlit"
+   "executionEnvironmentName":"[DataRobot] Python 3.12"
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
- Add codeowners
- Fix env name to new 3.12 python bare env
- Add minimum requirements txt

## Rationale
Add required packages for when environment no longer includes them