### PR TITLE
[Yolo-bug] Bump template version to 11.0.1

### DIFF
--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
       ],
       "source": {
          "repositoryUrl": "https://github.com/datarobot-oss/streamlit-app-base",
-         "releaseTag": "11.0.0"
+         "releaseTag": "11.0.1"
       },
       "previewImage": null
    },


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

Looks like the logo changes came in after 11.0.0 bump, go to 11.0.1 instead
