### PR TITLE
Add task dev / deploy support with DataRobot Pulumi infrastructure

### DIFF
--- a/.datarobot/cli/base.yml
+++ b/.datarobot/cli/base.yml
@@ -1,0 +1,21 @@
+---
+root:
+  - env: PULUMI_CONFIG_PASSPHRASE
+    type: secret_string
+    default: ""
+    optional: true
+    help: >
+      Enter the passphrase used to encrypt and decrypt the private key.
+      This value is required if you're not using Pulumi Cloud.
+  - env: DATAROBOT_DEFAULT_USE_CASE
+    type: string
+    default: ""
+    optional: true
+    help: "Enter the default Use Case for this application. If not set, a new Use Case will be created automatically."
+  - env: DATAROBOT_APPLICATION_ID
+    type: string
+    default: ""
+    optional: true
+    help: >
+      Enter the ID of an existing DataRobot Custom Application to replace.
+      Leave empty to create a new application.

--- a/.datarobot/cli/versions.yaml
+++ b/.datarobot/cli/versions.yaml
@@ -1,0 +1,26 @@
+---
+dr:
+  name: DataRobot CLI
+  minimum-version: 0.2.27
+  command: dr self version
+  url: https://github.com/datarobot-oss/cli
+uv:
+  name: uv Python package manager
+  minimum-version: 0.9.0
+  command: uv self version
+  url: https://docs.astral.sh/uv/getting-started/installation/
+git:
+  name: Git source control management tool
+  minimum-version: 2.30.0
+  command: git --version
+  url: https://git-scm.com/
+task:
+  name: Taskfile task runner
+  minimum-version: 3.43.3
+  command: task --version
+  url: https://taskfile.dev/
+pulumi:
+  name: Pulumi Infrastructure as Code tool
+  minimum-version: 3.163.0
+  command: pulumi version
+  url: https://www.pulumi.com/

--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,33 @@
+# ==============================================================================
+# Streamlit App Base - 環境変数テンプレート
+# ==============================================================================
+# このファイルを .env にコピーして必要な値を設定してください:
+#   cp .env.template .env
+# ==============================================================================
+
+# ---------- 必須設定 ----------
+
+# DataRobot API トークン
+DATAROBOT_API_TOKEN=
+
+# DataRobot API エンドポイント URL
+DATAROBOT_ENDPOINT=https://app.datarobot.com/api/v2
+
+# ---------- Pulumi インフラ設定（デプロイ時のみ必要） ----------
+
+# Pulumi スタック名
+PULUMI_STACK_NAME=streamlit-app-dev
+
+# Pulumi 暗号化パスフレーズ
+PULUMI_CONFIG_PASSPHRASE=
+
+# Pulumi アップデートチェックをスキップ（GitHub レート制限対策）
+PULUMI_SKIP_UPDATE_CHECK=1
+
+# DataRobot ユースケース（空の場合、新規作成）
+DATAROBOT_DEFAULT_USE_CASE=
+
+# ---------- 既存アプリ置換（オプション） ----------
+
+# 既存の DataRobot アプリケーションを置換する場合、そのアプリケーション ID を設定
+# DATAROBOT_APPLICATION_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,16 @@
+# Environment
+.env
+.env.*
+!.env.template
+
+# Pulumi
+pulumi_config.json
+Pulumi.*.yaml
+!infra/Pulumi.yaml
+
+# Virtual environments
+.venv/
+
 # JetBrains IDE
 .idea
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,75 @@
+---
+# Taskfile for Streamlit App Base
+# - `task dev` でローカル検証サーバーを起動
+# - `task deploy` (= `dr task run deploy`) で DataRobot へデプロイ
+version: '3'
+env:
+  ENV: testing
+dotenv: ['.env', '.env.{{.ENV}}']
+
+includes:
+  infra:
+    taskfile: ./infra/Taskfile.yaml
+    dir: ./infra
+
+tasks:
+  default:
+    desc: "Show all available tasks"
+    silent: true
+    cmds:
+      - task --list --sort none
+
+  start:
+    desc: "Prepare local development environment"
+    cmds:
+      - task: setup-env
+      - task: install
+      - echo 'Setup complete. Run `task dev` to start the app locally, or `task deploy` to deploy to DataRobot.'
+
+  setup-env:
+    desc: "Create .env from template if it does not exist"
+    status:
+      - test -f .env
+    cmds:
+      - cp .env.template .env
+      - echo '.env file created from .env.template. Please set DATAROBOT_API_TOKEN and DATAROBOT_ENDPOINT.'
+
+  install:
+    desc: "Install Python dependencies"
+    cmds:
+      - pip install -r src/requirements.txt
+
+  auth-check:
+    silent: true
+    desc: "Check DataRobot authentication"
+    cmds:
+      - |
+        if command -v dr &> /dev/null && dr auth help 2>&1 | grep -q "check"; then
+          echo "Checking authentication.."
+          dr auth check
+        else
+          echo "Skipping dr auth check (dr CLI not available). Ensure DATAROBOT_API_TOKEN is set in .env."
+        fi
+
+  dev:
+    desc: "Run Streamlit app locally for development"
+    deps:
+      - auth-check
+    cmds:
+      - echo "Starting Streamlit development server on http://localhost:8080"
+      - |
+        cd src && \
+        export token="$DATAROBOT_API_TOKEN" && \
+        export endpoint="$DATAROBOT_ENDPOINT" && \
+        streamlit run --server.port=8080 streamlit_app.py
+
+  deploy:
+    desc: "Deploy Streamlit app to DataRobot"
+    cmds:
+      - task: setup-env
+      - task: infra:deploy
+
+  destroy:
+    desc: "Destroy the deployed DataRobot application"
+    cmds:
+      - task: infra:destroy

--- a/infra/Pulumi.yaml
+++ b/infra/Pulumi.yaml
@@ -1,0 +1,13 @@
+---
+name: "streamlit-app-base"
+description: |-
+  Streamlit App Base - DataRobot Custom Application
+runtime:
+  name: python
+  options:
+    toolchain: uv
+config:
+  pulumi:tags:
+    value:
+      pulumi:template: python
+  datarobot:tracecontext: "streamlit-app-base"

--- a/infra/Taskfile.yaml
+++ b/infra/Taskfile.yaml
@@ -1,0 +1,139 @@
+---
+# https://taskfile.dev
+version: '3'
+
+vars:
+  UV_CMD:
+    sh: |
+      if command -v uv >/dev/null 2>&1; then
+        if command -v env >/dev/null 2>&1; then
+          echo "env -u PYTHONPATH -u VIRTUAL_ENV uv"
+        else
+          echo "uv"
+        fi
+      else
+        echo ""
+      fi
+
+  PULUMI_SKIP_UPDATE_CHECK:
+    sh: |
+      if [ -n "${PULUMI_SKIP_UPDATE_CHECK:-}" ]; then
+        echo "${PULUMI_SKIP_UPDATE_CHECK}"
+      else
+        echo "0"
+      fi
+
+  PULUMI_DATAROBOT_PLUGIN_VERSION:
+    sh: |
+      if [ -n "${PULUMI_DATAROBOT_PLUGIN_VERSION:-}" ]; then
+        echo "${PULUMI_DATAROBOT_PLUGIN_VERSION}"
+      else
+        echo "v0.10.27"
+      fi
+
+  PULUMI_DATAROBOT_DEFAULT_URL:
+    sh: |
+      if [ -n "${PULUMI_DATAROBOT_DEFAULT_URL:-}" ]; then
+        echo "${PULUMI_DATAROBOT_DEFAULT_URL}"
+      else
+        echo "https://github.com/datarobot-community/pulumi-datarobot/releases/download/v0.10.27"
+      fi
+
+tasks:
+  auth-check:
+    silent: true
+    desc: "Check authentication prerequisites"
+    cmds:
+      - |
+        if command -v dr &> /dev/null && dr auth help 2>&1 | grep -q "check"; then
+          echo "Checking authentication.."
+          dr auth check
+        else
+          echo "Skipping auth check (dr CLI not available)"
+        fi
+
+  pulumi-datarobot-plugin-check:
+    silent: true
+    cmds:
+      - |
+        if [ "{{.PULUMI_SKIP_UPDATE_CHECK}}" = "1" ]; then
+          {{.UV_CMD}} run pulumi plugin install resource datarobot {{.PULUMI_DATAROBOT_PLUGIN_VERSION}} \
+          --server {{.PULUMI_DATAROBOT_DEFAULT_URL}}
+        fi
+
+  install:
+    desc: "Install infra dependencies"
+    cmds:
+      - echo "Installing infra dependencies.."
+      - "{{.UV_CMD}} sync --all-extras --dev"
+
+  deploy:
+    silent: true
+    desc: "Deploy the Streamlit app to DataRobot"
+    aliases: [up]
+    deps:
+      - auth-check
+    cmds:
+      - task: pulumi-datarobot-plugin-check
+      - echo "Deploying Streamlit app to DataRobot.."
+      - "{{.UV_CMD}} run pulumi up {{.CLI_ARGS}}"
+
+  deploy-yes:
+    silent: true
+    desc: "Deploy (non-interactive, auto-confirm)"
+    deps:
+      - auth-check
+    cmds:
+      - task: pulumi-datarobot-plugin-check
+      - echo "Deploying Streamlit app to DataRobot (non-interactive).."
+      - "{{.UV_CMD}} run pulumi up -y {{.CLI_ARGS}}"
+
+  refresh:
+    silent: true
+    desc: "Refresh the infrastructure state"
+    deps:
+      - auth-check
+    cmds:
+      - task: pulumi-datarobot-plugin-check
+      - echo "Refreshing infrastructure.."
+      - "{{.UV_CMD}} run pulumi refresh {{.CLI_ARGS}}"
+
+  info:
+    silent: true
+    desc: "Show Pulumi stack info"
+    cmds:
+      - task: pulumi-datarobot-plugin-check
+      - "{{.UV_CMD}} run pulumi stack {{.CLI_ARGS}}"
+
+  init:
+    silent: true
+    desc: "Initialize a new Pulumi stack"
+    cmds:
+      - "{{.UV_CMD}} run pulumi stack init {{.CLI_ARGS}}"
+
+  select:
+    silent: true
+    desc: "Select a Pulumi stack"
+    cmds:
+      - "{{.UV_CMD}} run pulumi stack select {{.CLI_ARGS}}"
+
+  destroy:
+    silent: true
+    aliases: [down]
+    desc: "Destroy the deployed application"
+    deps:
+      - auth-check
+    cmds:
+      - task: pulumi-datarobot-plugin-check
+      - echo "Destroying the deployed application.."
+      - "{{.UV_CMD}} run pulumi destroy {{.CLI_ARGS}}"
+
+  destroy-yes:
+    silent: true
+    desc: "Destroy (non-interactive, auto-confirm)"
+    deps:
+      - auth-check
+    cmds:
+      - task: pulumi-datarobot-plugin-check
+      - echo "Destroying the deployed application (non-interactive).."
+      - "{{.UV_CMD}} run pulumi destroy -y {{.CLI_ARGS}}"

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -1,0 +1,42 @@
+"""
+Discover and load all Pulumi resource modules in the infra directory.
+Output exported variables to a configuration file for local development.
+"""
+
+from infra import *  # noqa: F403
+import importlib
+from pathlib import Path
+from os import getenv
+
+from datarobot_pulumi_utils.pulumi import default_collector, finalize
+
+DEFAULT_EXPORT_PATH: Path = Path(
+    getenv(
+        "PULUMI_EXPORT_PATH", str(Path(__file__).parent.parent / "pulumi_config.json")
+    )
+)
+INFRA_DIR = Path(__file__).parent / "infra"
+
+
+def import_infra_modules():
+    """Dynamically import all top-level modules in the infra package."""
+    for file_path in INFRA_DIR.glob("*.py"):
+        filename = file_path.name
+        if filename in ("__init__.py", "__main__.py"):
+            continue
+
+        module_name = f"infra.{filename[:-3]}"
+        module = importlib.import_module(module_name)
+
+        for attr in dir(module):
+            if attr.startswith("_"):
+                continue
+            globals()[attr] = getattr(module, attr)
+
+
+# Import all modules
+import_infra_modules()
+
+# Export outputs to JSON for local development
+default_collector.output_path = DEFAULT_EXPORT_PATH
+finalize()

--- a/infra/infra/__init__.py
+++ b/infra/infra/__init__.py
@@ -1,0 +1,26 @@
+"""
+Core Pulumi resources for Streamlit App Base.
+"""
+
+import os
+from pathlib import Path
+
+from datarobot_pulumi_utils.pulumi.stack import PROJECT_NAME
+import pulumi
+import pulumi_datarobot as datarobot
+
+__all__ = ["use_case", "project_dir"]
+
+project_dir = Path(__file__).parent.parent
+
+if use_case_id := os.environ.get("DATAROBOT_DEFAULT_USE_CASE"):
+    pulumi.info(f"Using existing use case '{use_case_id}'")
+    use_case = datarobot.UseCase.get(
+        id=use_case_id,
+        resource_name="Streamlit App Base [PRE-EXISTING]",
+    )
+else:
+    use_case = datarobot.UseCase(
+        resource_name=f"Streamlit App Base [{PROJECT_NAME}]",
+        description="Streamlit App Base - DataRobot Custom Application",
+    )

--- a/infra/infra/streamlit_app.py
+++ b/infra/infra/streamlit_app.py
@@ -1,0 +1,150 @@
+"""
+Deploy Streamlit application to DataRobot as a Custom Application.
+
+Supports both new deployment and replacing an existing application
+via the DATAROBOT_APPLICATION_ID environment variable.
+"""
+
+import os
+import re
+from pathlib import Path
+from typing import Final
+
+import pulumi
+import pulumi_datarobot
+from datarobot_pulumi_utils.schema.apps import ApplicationSourceArgs
+from datarobot_pulumi_utils.schema.apps import CustomAppResourceBundles
+from datarobot_pulumi_utils.schema.exec_envs import RuntimeEnvironments
+from datarobot_pulumi_utils.pulumi.stack import PROJECT_NAME
+
+from . import project_dir, use_case
+
+
+EXCLUDE_PATTERNS = [
+    re.compile(pattern)
+    for pattern in [
+        r".*tests/.*",
+        r".*\.coverage",
+        r".*\.DS_Store",
+        r".*\.pyc",
+        r".*\.ruff_cache/.*",
+        r".*\.venv/.*",
+        r".*\.mypy_cache/.*",
+        r".*__pycache__/.*",
+        r".*\.pytest_cache/.*",
+        r".*htmlcov/.*",
+        r".*\.data/.*",
+        r".*\.env",
+    ]
+]
+
+__all__ = [
+    "streamlit_app",
+    "streamlit_app_source",
+]
+
+# Path to the Streamlit application source
+streamlit_application_path = project_dir.parent / "src"
+
+# Runtime parameter definitions
+DATAROBOT_API_TOKEN: Final[str] = "DATAROBOT_API_TOKEN"
+DATAROBOT_ENDPOINT: Final[str] = "DATAROBOT_ENDPOINT"
+
+streamlit_app_runtime_parameters: list[
+    pulumi_datarobot.ApplicationSourceRuntimeParameterValueArgs
+] = [
+    pulumi_datarobot.ApplicationSourceRuntimeParameterValueArgs(
+        type="credential",
+        key=DATAROBOT_API_TOKEN,
+        value=os.environ.get(DATAROBOT_API_TOKEN, ""),
+    ),
+    pulumi_datarobot.ApplicationSourceRuntimeParameterValueArgs(
+        type="string",
+        key=DATAROBOT_ENDPOINT,
+        value=os.environ.get(DATAROBOT_ENDPOINT, "https://app.datarobot.com/api/v2"),
+    ),
+]
+
+
+def get_streamlit_app_files() -> list[tuple[str, str]]:
+    """Collect all application files from src/ for deployment."""
+    source_files = []
+    for dirpath, dirnames, filenames in os.walk(
+        streamlit_application_path, followlinks=True
+    ):
+        for filename in filenames:
+            file_path = os.path.join(dirpath, filename)
+            rel_path = os.path.relpath(file_path, streamlit_application_path)
+            rel_path = rel_path.replace(os.path.sep, "/")
+            source_files.append((os.path.abspath(file_path), rel_path))
+
+    source_files = [
+        (file_path, file_name)
+        for file_path, file_name in source_files
+        if not any(
+            exclude_pattern.match(file_name) for exclude_pattern in EXCLUDE_PATTERNS
+        )
+    ]
+    return source_files
+
+
+# --- Pulumi resources ---
+
+streamlit_app_resource_name: str = f"Streamlit App Base [{PROJECT_NAME}]"
+
+streamlit_app_source_args = ApplicationSourceArgs(
+    resource_name=streamlit_app_resource_name,
+    base_environment_id=RuntimeEnvironments.PYTHON_312_APPLICATION_BASE.value.id,
+).model_dump(mode="json", exclude_none=True)
+
+streamlit_app_source = pulumi_datarobot.ApplicationSource(
+    files=get_streamlit_app_files(),
+    runtime_parameter_values=streamlit_app_runtime_parameters,
+    resources=pulumi_datarobot.ApplicationSourceResourcesArgs(
+        resource_label=CustomAppResourceBundles.CPU_XL.value.id,
+    ),
+    **streamlit_app_source_args,
+)
+
+# Support replacing an existing application
+existing_app_id = os.environ.get("DATAROBOT_APPLICATION_ID", "")
+
+if existing_app_id:
+    pulumi.info(
+        f"Replacing existing application '{existing_app_id}' with new source"
+    )
+    streamlit_app = pulumi_datarobot.CustomApplication.get(
+        resource_name=f"{streamlit_app_resource_name} [EXISTING]",
+        id=existing_app_id,
+    )
+    # Update the existing application's source version
+    streamlit_app = pulumi_datarobot.CustomApplication(
+        resource_name=streamlit_app_resource_name,
+        source_version_id=streamlit_app_source.version_id,
+        use_case_ids=[use_case.id],
+        allow_auto_stopping=True,
+        resources=pulumi_datarobot.CustomApplicationResourcesArgs(
+            resource_label=CustomAppResourceBundles.CPU_XL.value.id,
+        ),
+        opts=pulumi.ResourceOptions(
+            depends_on=[streamlit_app_source],
+            import_=existing_app_id,
+        ),
+    )
+else:
+    streamlit_app = pulumi_datarobot.CustomApplication(
+        resource_name=streamlit_app_resource_name,
+        source_version_id=streamlit_app_source.version_id,
+        use_case_ids=[use_case.id],
+        allow_auto_stopping=True,
+        resources=pulumi_datarobot.CustomApplicationResourcesArgs(
+            resource_label=CustomAppResourceBundles.CPU_XL.value.id,
+        ),
+        opts=pulumi.ResourceOptions(depends_on=[streamlit_app_source]),
+    )
+
+pulumi.export("DATAROBOT_APPLICATION_ID", streamlit_app.id)
+pulumi.export(
+    f"{streamlit_app_resource_name} URL",
+    streamlit_app.application_url,
+)

--- a/infra/pyproject.toml
+++ b/infra/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "streamlit-app-base-infra"
+version = "0.0.1"
+description = "Streamlit App Base - DataRobot deployment infrastructure"
+requires-python = ">=3.11, <3.14"
+
+dependencies = [
+    "datarobot>=3.5.2",
+    "datarobot-pulumi-utils>=0.1.0",
+    "pulumi>=3.175.0",
+    "pulumi-datarobot>=0.10.27",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4.0",
+    "ruff>=0.3.0",
+]

--- a/src/metadata.yaml
+++ b/src/metadata.yaml
@@ -1,0 +1,7 @@
+name: runtime-params
+
+runtimeParameterDefinitions:
+  - fieldName: DATAROBOT_API_TOKEN
+    type: credential
+  - fieldName: DATAROBOT_ENDPOINT
+    type: string


### PR DESCRIPTION
- Taskfile.yml: `task dev` runs Streamlit locally, `task deploy` / `dr task run deploy` deploys to DataRobot
- infra/: Pulumi-based deployment as DataRobot CustomApplication (new or replace existing)
- .env.template: environment variable template with Japanese comments
- .datarobot/cli/: DataRobot CLI configuration (base.yml, versions.yaml)
- src/metadata.yaml: runtime parameter definitions for DataRobot

https://claude.ai/code/session_01Tc9xRo5DunTJ47m4nx4UYi

## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

_What is this pull request for?_

### Summary of Changes

_In general, what was changed? Screenshots are welcome too!_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new Pulumi-based deployment that can create or import/replace a DataRobot Custom Application, so misconfiguration could overwrite an existing app or deploy incorrect runtime parameters/resources.
> 
> **Overview**
> Adds a Taskfile-driven workflow for local dev and DataRobot deployment: `task dev` runs Streamlit with `DATAROBOT_API_TOKEN`/`DATAROBOT_ENDPOINT`, while `task deploy`/`destroy` delegates to new infra tasks.
> 
> Introduces a Pulumi project under `infra/` that packages `src/` into a `pulumi_datarobot.ApplicationSource`, creates (or *imports and replaces* via `DATAROBOT_APPLICATION_ID`) a `CustomApplication`, and optionally reuses an existing Use Case via `DATAROBOT_DEFAULT_USE_CASE`; exports `DATAROBOT_APPLICATION_ID` and app URL to `pulumi_config.json`.
> 
> Adds repo scaffolding/config: `.env.template`, updated `.gitignore` for env/Pulumi artifacts, DataRobot CLI env/version config under `.datarobot/cli/`, and `src/metadata.yaml` defining runtime parameters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 627073f887de62228e0897fd5ee891fc24cd66cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->