### PR TITLE
Modernize Streamlit App Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,123 @@
 # Streamlit app base template
 
-In this repository you will find an empty Streamlit application base template to kickstart custom application development. The Datarobot client is already set up for you to use. It uses the application owner's API key by default.
+An empty Streamlit application base template to kickstart custom application development.
+The DataRobot client is pre-configured and uses the application owner's API key automatically.
+The template includes example tabs that fetch and display live data from the DataRobot API
+(version info, projects, deployments, use cases) to give you a concrete starting point.
 
 ## Setup
 
-You can run the app using a custom application or by running the Streamlit app directly. Custom applications can be created either via the NextGen Registry's **Applications** page or by using [DRApps](https://github.com/datarobot/dr-apps/blob/main/README.md).
+### Running locally
 
-Be sure to define the required variables for the app to communicate with DataRobot. If you run the app locally or in another environment than a custom application, you'll need to set the env variables. When this app is run via a custom application, the variables are set automatically.
-
-```shell
-#start-app.sh
-export token="$DATAROBOT_API_TOKEN"  # Your API key, accessed from DataRobot's Developer Tools page
-export endpoint="$DATAROBOT_ENDPOINT"  # Example: https://app.datarobot.com/api/v2/
-```
-
-## Add and use runtime parameters
-
-To add runtime parameters, create a `metadata.yaml` file in your application source folder. Here is an example of a `DEPLOYMENT_ID` that creates 
-an environment variable called `MLOPS_RUNTIME_PARAM_DEPLOYMENT_ID`:
-
-```yaml
-runtimeParameterDefinitions:
-- fieldName: DEPLOYMENT_ID
-  type: string
-```
-
-Once this file is part of your application source in DataRobot, it displays the new runtime parameter(s) as part of the
-app configuration.
-
-To use the parameters, DataRobot recommends you add them via `start-app.sh`. Add the following conditional export before `streamlit run` starts:
+Install dependencies with [uv](https://docs.astral.sh/uv/):
 
 ```shell
-if [ -n "$MLOPS_RUNTIME_PARAM_DEPLOYMENT_ID" ]; then
-  export deployment_id="$MLOPS_RUNTIME_PARAM_DEPLOYMENT_ID"
-fi
+cd src
+uv sync
 ```
 
-You can now use `os.getenv("deployment_id")` within your application code. DataRobot suggests you add every new environment variable to the `initiate_session_state` function, that way they can be used across the app with ease.
+Set the required environment variables:
+
+```shell
+export DATAROBOT_API_TOKEN="<your API token>"   # Developer Tools page in DataRobot
+export DATAROBOT_ENDPOINT="https://app.datarobot.com/api/v2"
+```
+
+Then start the app:
+
+```shell
+uv run streamlit run streamlit_app.py
+```
+
+### Running as a Custom Application
+
+Custom applications can be created via the NextGen Registry's **Applications** page or
+with [DRApps](https://github.com/datarobot/dr-apps/blob/main/README.md).
+
+When running as a Custom Application, `DATAROBOT_API_TOKEN` and `DATAROBOT_ENDPOINT` are
+injected by the platform automatically — no manual configuration needed.
+
+## Making DataRobot API calls
+
+`utils.py` provides a `_get(path)` helper that makes authenticated GET requests using the
+token and endpoint stored in Streamlit session state. Use it to call any DataRobot API endpoint:
+
+```python
+from utils import _get
+
+projects = _get("/projects/")
+deployments = _get("/deployments/")
+```
+
+For calls that should be cached across reruns (e.g. user info), use `@st.cache_data`:
+
+```python
+@st.cache_data(show_spinner=False)
+def get_my_data(token: str, endpoint: str) -> dict | None:
+    return _get("/my-endpoint/")
+```
+
+Pass `st.session_state.token` and `st.session_state.endpoint` as arguments so the cache
+invalidates automatically if the credentials change.
+
+## Add runtime parameters
+
+Runtime parameters let you configure the app from the DataRobot UI without changing code.
+A commented-out example is provided in `metadata.yaml.sample`. To activate it:
+
+**Step 1** — Copy `metadata.yaml.sample` to `metadata.yaml` 
+
+**Step 2** — Uncomment the block in `metadata.yaml` and set your parameter name.
+
+**Step 3** — Add the corresponding field to `Config` in `config.py`:
+
+```python
+class Config(DataRobotAppFrameworkBaseSettings):
+    deployment_id: str = ""
+```
+
+`DataRobotAppFrameworkBaseSettings` reads the `MLOPS_RUNTIME_PARAM_DEPLOYMENT_ID` env var
+that the platform injects and exposes it as `Config().deployment_id` — no shell script
+exports needed.
+
+**Step 3** — Use it in your app:
+
+```python
+from config import Config
+
+config = Config()
+deployment_id = config.deployment_id
+```
+
+## LLM Gateway
+
+The **LLM Gateway** tab shows all models available to your DataRobot account and lets you
+send a single-turn chat message. Model discovery uses `datarobot.genai.LLMGatewayCatalog`;
+chat goes through [LiteLLM](https://github.com/BerriAI/litellm) with the `datarobot/` model prefix.
+
+For a full multi-turn chat application with streaming, citations, and deployment support,
+see the [QA App Streamlit](https://github.com/datarobot-oss/qa-app-streamlit) template.
+
+## Health check
+
+Streamlit exposes a built-in health endpoint at `/_stcore/health`. The DataRobot platform
+uses this automatically — no custom implementation needed.
 
 ## Streamlit configuration file
 
-This base template comes with a `config.toml` file in the `src/.streamlit` directory. You can adjust your app preferences in this file ([read more](https://docs.streamlit.io/develop/concepts/configuration/theming)). There are some preset defaults show in the code below.
+This template includes a `config.toml` in `src/.streamlit/` with sensible defaults.
+Adjust it to your preferences ([read more](https://docs.streamlit.io/develop/concepts/configuration/theming)):
 
 ```toml
 [browser]
 gatherUsageStats = false            # Disables component usage tracking by Streamlit
 
 [theme]
-base="dark" 
+base="dark"
 primaryColor="#297ab4"              # Accent color of user interaction elements (button, checkbox, etc.)
 backgroundColor="#0e1117"           # Background for the main content area
 secondaryBackgroundColor="#22272b"  # Background for sidebar and various interactive widgets
 
 [client]
-toolbarMode = "minimal"             # Hides the Streamlit actions from the toolbar (clear cache, rerun, custom themes)
+toolbarMode = "minimal"             # Hides the Streamlit actions from the toolbar
 ```

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,16 @@
+from datarobot.core.config import DataRobotAppFrameworkBaseSettings
+
+
+class Config(DataRobotAppFrameworkBaseSettings):
+    # Declare your runtime parameters here — each field maps to an entry in metadata.yaml.
+    # DataRobotAppFrameworkBaseSettings reads them from the MLOPS_RUNTIME_PARAM_* env vars
+    # that the platform injects automatically, so no manual exports in start-app.sh are needed.
+    #
+    # Example — add a deployment ID runtime parameter:
+    #   deployment_id: str = ""
+    #
+    # Then add the corresponding entry to metadata.yaml:
+    #   runtimeParameterDefinitions:
+    #   - fieldName: DEPLOYMENT_ID
+    #     type: string
+    pass

--- a/src/metadata.yaml.sample
+++ b/src/metadata.yaml.sample
@@ -1,0 +1,9 @@
+# Runtime parameters let you configure the app from the DataRobot UI without changing code.
+# Uncomment and edit the block below to add your own parameters, then add the corresponding
+# fields to the Config class in config.py.
+#
+# runtimeParameterDefinitions:
+# - fieldName: DEPLOYMENT_ID
+#   type: string
+#   defaultValue: ""
+#   description: "ID of the DataRobot deployment this app will interact with."

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -1,0 +1,40 @@
+[project]
+name = "streamlit-app-base"
+version = "0.1.0"
+description = "DataRobot Streamlit application template"
+requires-python = ">=3.12,<3.13"
+dependencies = [
+    "streamlit>=1.38.0",
+    "datarobot>=3.6.0",
+    "requests>=2.33.0",
+    "litellm>=1.67.0",
+    "pydantic-settings>=2.0.0",
+]
+
+[dependency-groups]
+dev = [
+    "ruff>=0.11.0",
+]
+
+[tool.uv]
+package = false
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "F",   # pyflakes
+    "I",   # isort
+    "UP",  # pyupgrade
+    "B",   # flake8-bugbear
+    "SIM", # flake8-simplify
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["config", "constants", "utils"]
+
+[tool.ruff.format]
+quote-style = "double"

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,0 @@
-streamlit>=1.38.0
-datarobot>=3.5.2

--- a/src/start-app.sh
+++ b/src/start-app.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 echo "Starting App"
-
-export token="$DATAROBOT_API_TOKEN"
-export endpoint="$DATAROBOT_ENDPOINT"
-export app_base_url_path="$STREAMLIT_SERVER_BASE_URL_PATH"
-
 streamlit run --server.port=8080 streamlit_app.py

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -3,22 +3,129 @@ from datarobot import Client
 from datarobot.client import set_client
 
 from constants import *
-from utils import initiate_session_state
+from utils import (
+    get_current_user,
+    get_deployments,
+    get_llm_models,
+    get_projects,
+    get_use_cases,
+    get_version,
+    initiate_session_state,
+    llm_chat,
+)
 
 # Basic application page configuration, modify values in `constants.py`
-st.set_page_config(page_title=I18N_APP_NAME, page_icon=APP_FAVICON, layout=APP_LAYOUT,
-                   initial_sidebar_state=SIDEBAR_DEFAULT_STATE)
+st.set_page_config(
+    page_title=I18N_APP_NAME,
+    page_icon=APP_FAVICON,
+    layout=APP_LAYOUT,
+    initial_sidebar_state=SIDEBAR_DEFAULT_STATE,
+)
 
 
 def start_streamlit():
-    initiate_session_state()
+    # Setup DR client — reads DATAROBOT_API_TOKEN and DATAROBOT_ENDPOINT automatically.
+    # If credentials are missing or invalid the app shows an actionable error instead of
+    # crashing with a stack trace.
+    try:
+        dr = Client()
+    except Exception as exc:
+        st.error(
+            "Could not connect to DataRobot. "
+            "Make sure **DATAROBOT_API_TOKEN** and **DATAROBOT_ENDPOINT** are set correctly.\n\n"
+            f"`{exc}`"
+        )
+        st.stop()
 
-    # Setup DR client
-    set_client(Client(token=st.session_state.token, endpoint=st.session_state.endpoint))
+    set_client(dr)
+    initiate_session_state(dr)
 
-    st.logo(APP_LOGO)
-    st.header('Hello world')
-    st.text('This is a Streamlit application base template to kickstart your custom app development!')
+    token = st.session_state.token
+    endpoint = st.session_state.endpoint
+
+    with st.sidebar:
+        st.logo(APP_LOGO)
+
+        user = get_current_user(token, endpoint)
+        if user:
+            st.write(f"**{user.get('username', '')}**")
+            st.caption(user.get('email', ''))
+            st.success("Connected", icon="✅")
+        else:
+            st.error("DataRobot unreachable", icon="🔴")
+
+        st.divider()
+        st.caption("Resources")
+        st.markdown(
+            "[📖 App Templates]"
+            "(https://docs.datarobot.com/en/docs/wb-apps/app-templates/index.html)"
+        )
+        st.markdown(
+            "[⚙️ Custom App API Reference]"
+            "(https://docs.datarobot.com/en/docs/api/reference/public-api/custom_applications.html)"
+        )
+        if st.session_state.apidocs_url:
+            st.markdown(
+                f"[🔌 DataRobot API Docs]({st.session_state.apidocs_url})"
+            )
+
+    st.header(I18N_APP_NAME)
+    if I18N_APP_DESCRIPTION:
+        st.write(I18N_APP_DESCRIPTION)
+
+    # -----------------------------------------------------------------------
+    # Example: fetch and display DataRobot data.
+    # Replace or extend these tabs with your own application logic.
+    # -----------------------------------------------------------------------
+    tab_version, tab_projects, tab_deployments, tab_use_cases, tab_llm = st.tabs(
+        ["API Version", "My Projects", "My Deployments", "My Use Cases", "LLM Gateway"]
+    )
+
+    with tab_version:
+        data = get_version()
+        if data:
+            st.json(data)
+
+    with tab_projects:
+        data = get_projects()
+        if data:
+            st.json(data)
+
+    with tab_deployments:
+        data = get_deployments()
+        if data:
+            st.json(data)
+
+    with tab_use_cases:
+        data = get_use_cases()
+        if data:
+            st.json(data)
+
+    with tab_llm:
+        st.markdown(
+            "Send a message to any model available in the DataRobot LLM Gateway.\n\n"
+            "For a more advanced chat interface check out the [Q&A App Streamlit](https://github.com/datarobot-oss/qa-app-streamlit) template."
+        )
+
+        models = get_llm_models(token, endpoint)
+        if not models:
+            st.info(
+                "No LLM Gateway models found. "
+                "Check that your DataRobot account has LLM Gateway access."
+            )
+        else:
+            model = st.selectbox("Model", options=list(models))
+            prompt = st.text_area("Message", placeholder="Ask something…")
+            if st.button("Send", disabled=not prompt):
+                with st.spinner("Thinking…"):
+                    response = llm_chat(
+                        model,
+                        [{"role": "user", "content": prompt}],
+                        token,
+                        endpoint,
+                    )
+                if response:
+                    st.markdown(response)
 
 
 if __name__ == "__main__":

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,11 +1,118 @@
-import os
+import logging
+from urllib.parse import urlparse
 
+import requests
 import streamlit as st
+from datarobot import Client
+
+logger = logging.getLogger(__name__)
 
 
-def initiate_session_state():
-    # Env variables
-    if 'token' not in st.session_state:
-        st.session_state.token = os.getenv("token")
-    if 'endpoint' not in st.session_state:
-        st.session_state.endpoint = os.getenv("endpoint")
+def initiate_session_state(dr: Client) -> None:
+    if "token" not in st.session_state:
+        st.session_state.token = dr.token
+    if "endpoint" not in st.session_state:
+        st.session_state.endpoint = dr.endpoint
+    if "apidocs_url" not in st.session_state:
+        parsed = urlparse(dr.endpoint.rstrip("/"))
+        st.session_state.apidocs_url = (
+            f"{parsed.scheme}://{parsed.netloc}/apidocs/" if parsed.netloc else None
+        )
+
+
+def _get(path: str) -> dict | list | None:
+    """Make an authenticated GET request to the DataRobot API."""
+    token = st.session_state.token
+    endpoint = st.session_state.endpoint
+    try:
+        resp = requests.get(
+            f"{endpoint.rstrip('/')}/{path.lstrip('/')}",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except requests.HTTPError as exc:
+        logger.error("DataRobot API error for %s: %s", path, exc)
+        st.error(f"DataRobot API error: {exc}")
+    except Exception as exc:
+        logger.exception("Request failed for %s", path)
+        st.error(f"Request failed: {exc}")
+    return None
+
+
+@st.cache_data(show_spinner=False)
+def get_current_user(token: str, endpoint: str) -> dict | None:
+    """Fetch the authenticated user's account info (/account/info/)."""
+    try:
+        resp = requests.get(
+            f"{endpoint.rstrip('/')}/account/info/",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except Exception:
+        logger.exception("Failed to fetch current user")
+        return None
+
+
+def get_version() -> dict | None:
+    """Fetch the DataRobot platform version (/version/)."""
+    return _get("/version/")
+
+
+def get_projects() -> dict | None:
+    """Fetch the list of projects (/projects/)."""
+    return _get("/projects/")
+
+
+def get_deployments() -> dict | None:
+    """Fetch the list of deployments (/deployments/)."""
+    return _get("/deployments/")
+
+
+def get_use_cases() -> dict | None:
+    """Fetch the list of use cases (/useCases/)."""
+    return _get("/useCases/")
+
+
+@st.cache_data(show_spinner=False)
+def get_llm_models(token: str, endpoint: str) -> list[str]:
+    """List model names available in the DataRobot LLM Gateway (/genai/llmgw/catalog/)."""
+    try:
+        resp = requests.get(
+            f"{endpoint.rstrip('/')}/genai/llmgw/catalog/",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data = resp.json().get("data", [])
+        return [item["model"] for item in data]
+    except Exception:
+        logger.exception("Failed to fetch LLM Gateway models")
+        return []
+
+
+def llm_chat(model: str, messages: list[dict], token: str, endpoint: str) -> str | None:
+    """Send a chat request to the DataRobot LLM Gateway via LiteLLM.
+
+    LiteLLM routes to DataRobot when the model name carries a "datarobot/" prefix.
+    Model names returned by get_llm_models() are accepted as-is.
+    """
+    import litellm
+
+    try:
+        if not model.startswith("datarobot/"):
+            model = f"datarobot/{model}"
+        response = litellm.completion(
+            model=model,
+            messages=messages,
+            api_key=token,
+            api_base=endpoint,
+        )
+        return response.choices[0].message.content
+    except Exception as exc:
+        logger.exception("LLM Gateway chat failed")
+        st.error(f"LLM Gateway error: {exc}")
+        return None

--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
       ],
       "source": {
          "repositoryUrl": "https://github.com/datarobot-oss/streamlit-app-base",
-         "releaseTag": "11.0.1"
+         "releaseTag": "11.8.1"
       },
       "previewImage": null
    },


### PR DESCRIPTION
### Summary of Changes

Modernize the Streamlit starter app from a static “hello world” into a working example that connects to DataRobot at startup, shows connection status in the sidebar, and renders tabs that fetch and display live API data (version, projects, deployments, use cases).

<img width="1824" height="1126" alt="Screenshot 2026-04-10 at 22 26 31" src="https://github.com/user-attachments/assets/3e9b7cfe-5506-429b-9a87-0826a7ce63f2" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes startup/auth wiring and adds new outbound API calls (including LiteLLM chat) that affect runtime behavior and dependency set, but it’s confined to a template app.
> 
> **Overview**
> Replaces the static “hello world” starter with a working Streamlit template that initializes a DataRobot client on startup, surfaces connection/user status in the sidebar, and adds example tabs that fetch and display live DataRobot API data (version, projects, deployments, use cases) plus an **LLM Gateway** single-turn chat demo.
> 
> Adds `utils._get()` plus cached helpers and error handling/logging for DataRobot API requests, updates `start-app.sh` to rely on platform-injected credentials, and introduces runtime-parameter scaffolding via `config.py` + `metadata.yaml.sample`.
> 
> Modernizes project packaging by moving from `requirements.txt` to `pyproject.toml` (uv/Ruff tooling) and bumps `template_info.json` `releaseTag` to `11.8.1`, with README updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 157f7aa0f8f2debac5e679afbaa39d76123859cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->